### PR TITLE
Don't check for SSL certificate authenticity when connecting to Mailchimp API

### DIFF
--- a/lib/WWW/Mailchimp.pm
+++ b/lib/WWW/Mailchimp.pm
@@ -132,7 +132,7 @@ has 'json' => (
 
 sub _build_lwp {
   my $self = shift;
-  my $ua = LWP::UserAgent->new( timeout => $self->timeout, agent => __PACKAGE__ . ' ' . $VERSION );
+  my $ua = LWP::UserAgent->new( timeout => $self->timeout, agent => __PACKAGE__ . ' ' . $VERSION, ssl_opts => { verify_hostname => 0 } );
 }
 
 sub _build_json { JSON->new->allow_nonref }


### PR DESCRIPTION
Don't check for SSL certificate authenticity when connecting to Mailchimp API
