### PR TITLE
URL-encode json parameters

### DIFF
--- a/lib/WWW/Mailchimp.pm
+++ b/lib/WWW/Mailchimp.pm
@@ -3,11 +3,12 @@ use Moo;
 use LWP;
 use JSON;
 use URI;
+use URI::Escape;
 use PHP::HTTPBuildQuery qw(http_build_query);
 use MooX::Types::MooseLike::Base qw(Int InstanceOf Num Str);
 use Sub::Name;
 
-our $VERSION = '0.007_01';
+our $VERSION = '0.007_02';
 $VERSION = eval $VERSION;
 
 =head1 NAME
@@ -172,7 +173,7 @@ sub _request {
   # build a POST request with json-encoded arguments
   my $post_args = $self->_build_query_args(%args);
   my $req = HTTP::Request->new('POST', $uri);
-  $req->content( $self->json->encode($post_args) );
+  $req->content( uri_escape( $self->json->encode($post_args) ) );
 
   my $response = $self->request( $req );
   return $response->is_success ? $self->json->decode($response->content) : $response->status_line;


### PR DESCRIPTION
I think I neglected to read that part - http://apidocs.mailchimp.com/api/rtfm/#input-parameters
